### PR TITLE
add get all inventory items

### DIFF
--- a/routes/routes-inventories.js
+++ b/routes/routes-inventories.js
@@ -2,7 +2,7 @@ const router = require('express').Router();
 const inventories = require("../controllers/inventory-controller");
 
 router.route('/')
-    .get(inventories.index);
+    .get(inventories.allInventoryItems);
     // add route for adding
 router.route("/:id")
     .delete(inventories.remove)


### PR DESCRIPTION
Created request for getting all inventory list items. Returns an array of objects. The key/value pair of warehouse_id is replaced by the name of the warehouse e.g. {warehouse_name: Washington}. There is almost definitely a way to do this with knex.join but this works for now - may revisit knex.join for this if there is time.

Also commented out the index async function.